### PR TITLE
Fix sidebar resizing for real

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -65,10 +65,37 @@ class TimerExtension {
     }
   }
 
+  private fixSidebar() {
+    setTimeout(this.tryFixSidebar.bind(this), 100);
+  }
+
+  // Check if our sidebar has been restyled and resize it if possible
+  // Continues fixSidebar loop if the sidebar has not yet been restyled
+  private tryFixSidebar() {
+    if (this.sidebarStylesApplied()) {
+      this.simulateResize();
+    } else {
+      this.fixSidebar();
+    }
+  }
+
+  // Probe to check whether the sidebar has been restyled
+  // We alter the sidebar to not have a border so we check
+  // the computed styles to determine whether it has been updated
+  private sidebarStylesApplied(): boolean {
+    const scroll = document.querySelector(".myscroll");
+
+    if (scroll === null) throw "Expected to find scroll div";
+
+    const computedBorder: string = getComputedStyle(scroll).borderTop || "";
+
+    return computedBorder.substr(0, 3) === "1px";
+  }
+
   // We restyle the sidebar and this results in it only filling half the
   // page. CSTimer automatically resizes the sidebar on window resize events
   // so we manually trigger changes after our other changes are injected
-  private fixSidebar() {
+  private simulateResize() {
     const event = document.createEvent("HTMLEvents");
     event.initEvent("resize", true, false);
     document.dispatchEvent(event);


### PR DESCRIPTION
Sometimes the sidebar isn't resized after we apply our styles. This
happens when our script is injected after the entire cstimer app
has already loaded. We can force this condition to reproduce the
problem by changing our entrypoint to

    setTimeout(function(){
      (new TimerExtension(localStorage, fixedSettings)).setup();
    }, 1000)

The solution is to check the computed styles of the sidebar every
100ms until we can observe one of our style changes. Once we
detect our change we trigger a window resize event which cstimer
listens to so it can resize various UI elements.